### PR TITLE
Fix update workflow

### DIFF
--- a/.github/workflows/handle_updates.yml
+++ b/.github/workflows/handle_updates.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Python and Poetry
         uses: ITProKyle/action-setup-python@v0.1.0
         with:
-          python-version: 3.10
+          python-version: "3.10"  # String keeps this from being interpreted as a float
 
       - name: Set up poetry virtualenv
         run: poetry install
@@ -39,7 +39,7 @@ jobs:
       - name: Install Python and Poetry
         uses: ITProKyle/action-setup-python@v0.1.0
         with:
-          python-version: 3.6
+          python-version: 3.7
 
       - name: Set up poetry virtualenv
         run: poetry install


### PR DESCRIPTION
Fixes (hopefully 🤞) an issue where the `python-version` was being interpreted as a float, so 3.10 was being converted to 3.1. Also, I must have missed changing the target Python version for the pyredox library to 3.7 when it dropped support for 3.6.